### PR TITLE
CD 워크플로 오류 해결 - 빌드 단계에 yml 포함 및 Jasypt 설정 추가

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -19,6 +19,27 @@ jobs:
       checks: write
       pull-requests: write
 
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: 1234
+          MYSQL_DATABASE: wearweather
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -p$${MYSQL_ROOT_PASSWORD} || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-start-period=30s
+          --health-retries=10
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,6 +60,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Clean Build With Gradle Wrapper
+        env:
+          SPRING_PROFILES_ACTIVE: local
+          JASYPT_ENCRYPTOR_PASSWORD: ${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }}
         run: ./gradlew clean build
 
       - name: Publish Test Results


### PR DESCRIPTION
## 🚩 연관 이슈
close #135 

## 🗣️ 작업 개요
- CD 워크플로가 설정 누락(application*.yml 미포함 / Jasypt 키 미전달)으로 실패하여, 빌드 결과물에 설정을 포함하고 JASYPT 복호화 키를 주입하도록 수정


## 📝 작업 내용
- Gradle 빌드 시 application*.yml 리소스 포함
- 워크플로에 JASYPT_ENCRYPTOR_PASSWORD 시크릿 주입

