### PR TITLE
도메인 .store→.com 전환에 따른 CORS 및 쿠키 도메인 정책 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
@@ -21,10 +21,10 @@ public class CorsConfig {
             "http://localhost:5174",
             "https://look-at-the-weather.vercel.app/",
             "https://localhost:5173",
-            "https://lookattheweather.store",
             "https://dev.lookattheweather.com",
             "https://dev-apis.lookattheweather.com",
-            "https://www.lookattheweather.store"));
+            "https://lookattheweather.com",
+            "https://www.lookattheweather.com"));
         config.setAllowedMethods(Arrays.asList("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/src/main/java/com/WearWeather/wear/global/jwt/JwtCookieManager.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/JwtCookieManager.java
@@ -13,7 +13,6 @@ public class JwtCookieManager {
 
     private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-    private static final String DOMAIN = ".lookattheweather.store";
     private static final String LOCALHOST = "localhost";
 
     private static final int ACCESS_TOKEN_EXPIRATION = 24 * 60 * 60; // 24시간
@@ -41,7 +40,6 @@ public class JwtCookieManager {
           .httpOnly(true)
           .secure(!isLocal)  // 로컬이면 false, 운영이면 true
           .sameSite(isLocal ? "Lax" : "Strict")  // 로컬은 Lax, 운영은 Strict
-          .domain(isLocal ? LOCALHOST : DOMAIN) // 로컬이면 localhost, 운영이면 도메인 지정
           .maxAge(maxAge)
           .build();
 


### PR DESCRIPTION
## 🚩 연관 이슈
close #137 

## 🗣️ 작업 개요
- 도메인 주소가 .store → .com 으로 변경됨
- prod/dev 분리 환경에 맞춰 CORS 정책과 쿠키 도메인 정책 수정

## 📝 작업 내용
- CORS 정책 적용
- 운영 고정 도메인(.lookattheweather.com) 제거 → 호스트 전용(host-only) 쿠키로 전환
